### PR TITLE
Remove .zuul.yaml

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,8 +1,0 @@
----
-- project:
-    check:
-      jobs:
-        - ansible-tox-linters
-    gate:
-      jobs:
-        - ansible-tox-linters


### PR DESCRIPTION
We've moved these jobs into ansible/project-config to better centrally
manage network project for now.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>