### PR TITLE
Add ansible pep8 exceptions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,6 @@ commands = {posargs}
 [flake8]
 # These are ignored intentionally;
 # please don't submit patches that solely correct them or enable them.
-ignore = E125,E129,H
+ignore = E125,E129,E402,W503,W504,E741
 show-source = True
 exclude = .venv,.tox,dist,doc,build,*.egg


### PR DESCRIPTION
This commit adds ansible linter exceptions from [1] to ansible
networking repo.

[1] https://github.com/ansible/ansible/blob/devel/test/sanity/pep8/current-ignore.txt